### PR TITLE
use CodeCov upload

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,17 +1,33 @@
-name: Branch CI
+coverage_upload:
+    needs: [node_ci]
+    environment: CI
+    name: CodeCov upload
 
-on:
-  push:
-    branches:
-      - '*'
-      - '!main'
+    steps:
+      - name: "⬇️ Download the client test coverage report"
+        uses: actions/download-artifact@v3
+        with:
+          name: client-coverage-file
 
-jobs:
+      - name: "📜 Copy the client coverage file"
+        run: |
+          mv coverage-final.json coverage-final-client.json
 
-  node_ci:
-    name: Node CI
-    uses: ./.github/workflows/node_ci.yml
+      - name: "⬇️ Download the server test coverage report"
+        uses: actions/download-artifact@v3
+        with:
+          name: server-coverage-file
 
-  docker_ci:
-    name: Docker CI
-    uses: ./.github/workflows/docker_ci.yml
+      - name: "📜 Copy the server coverage file"
+        run: |
+          mv coverage-final.json coverage-final-server.json
+
+      - name: "🌪️ Publish to CodeCov"
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          flags: unittests
+          files: ./coverage-final-client.json,./coverage-final-server.json
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          # verbose: true # optional (default = false)

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,4 +1,22 @@
-coverage_upload:
+name: Branch CI
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!main'
+
+jobs:
+
+  node_ci:
+    name: Node CI
+    uses: ./.github/workflows/node_ci.yml
+
+  docker_ci:
+    name: Docker CI
+    uses: ./.github/workflows/docker_ci.yml
+
+  coverage_upload:
     needs: [node_ci]
     environment: CI
     name: CodeCov upload

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -19,6 +19,7 @@ jobs:
   coverage_upload:
     needs: [node_ci]
     environment: CI
+    runs-on: ubuntu-latest
     name: CodeCov upload
 
     steps:

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   build_docker_client:
-    name: "🐳 Build Docker (CLIENT) Image"
+    name: "🐳 Build/Publish Docker (CLIENT) Image"
     runs-on: ubuntu-latest
     env:
      working-directory: client

--- a/.github/workflows/node_ci.yml
+++ b/.github/workflows/node_ci.yml
@@ -147,37 +147,3 @@ jobs:
           name: server-coverage-file
           path: ${{ env.working-directory }}/coverage/coverage-final.json
           retention-days: 3
-
-  coverage_upload:
-    name: Test Coverage Upload (CodeCov)
-    needs: [client_test, server_test]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "⬇️ Download the client test coverage report"
-        uses: actions/download-artifact@v3
-        with:
-          name: client-coverage-file
-
-      - name: "📜 Copy the client coverage file"
-        run: |
-          mv coverage-final.json coverage-final-client.json
-
-      - name: "⬇️ Download the server test coverage report"
-        uses: actions/download-artifact@v3
-        with:
-          name: server-coverage-file
-
-      - name: "📜 Copy the server coverage file"
-        run: |
-          mv coverage-final.json coverage-final-server.json
-
-      - name: "🌪️ Publish to CodeCov"
-        uses: codecov/codecov-action@v2
-        with:
-          # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          flags: unittests
-          files: ./coverage-final-client.json,./coverage-final-server.json
-          name: codecov-umbrella # optional
-          fail_ci_if_error: true # optional (default = false)
-          # verbose: true # optional (default = false)

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,13 +3,48 @@ name: CI/CD
 on:
   push:
     branches:
-      - '*'
+      - 'main'
 
 jobs:
 
   node_ci:
     name: Node CI
     uses: ./.github/workflows/node_ci.yml
+
+  coverage_upload:
+    needs: [node_ci]
+    environment: CI
+    name: CodeCov upload
+
+    steps:
+      - name: "⬇️ Download the client test coverage report"
+        uses: actions/download-artifact@v3
+        with:
+          name: client-coverage-file
+
+      - name: "📜 Copy the client coverage file"
+        run: |
+          mv coverage-final.json coverage-final-client.json
+
+      - name: "⬇️ Download the server test coverage report"
+        uses: actions/download-artifact@v3
+        with:
+          name: server-coverage-file
+
+      - name: "📜 Copy the server coverage file"
+        run: |
+          mv coverage-final.json coverage-final-server.json
+
+      - name: "🌪️ Publish to CodeCov"
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          flags: unittests
+          files: ./coverage-final-client.json,./coverage-final-server.json
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          # verbose: true # optional (default = false)
+
 
   docker_ci:
     name: Docker CI

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -13,6 +13,7 @@ jobs:
 
   coverage_upload:
     needs: [node_ci]
+    runs-on: ubuntu-latest
     environment: CI
     name: CodeCov upload
 


### PR DESCRIPTION
Issue #43
```yml
coverage_upload:
    needs: [node_ci]
    environment: CI
    name: CodeCov upload

    steps:
      - name: "⬇️ Download the client test coverage report"
        uses: actions/download-artifact@v3
        with:
          name: client-coverage-file

      - name: "📜 Copy the client coverage file"
        run: |
          mv coverage-final.json coverage-final-client.json

      - name: "⬇️ Download the server test coverage report"
        uses: actions/download-artifact@v3
        with:
          name: server-coverage-file

      - name: "📜 Copy the server coverage file"
        run: |
          mv coverage-final.json coverage-final-server.json

      - name: "🌪️ Publish to CodeCov"
        uses: codecov/codecov-action@v2
        with:
          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
          flags: unittests
          files: ./coverage-final-client.json,./coverage-final-server.json
          name: codecov-umbrella # optional
          fail_ci_if_error: true # optional (default = false)
          # verbose: true # optional (default = false)

```